### PR TITLE
Introduce macro for chart building

### DIFF
--- a/src/main/tech/thomas_sojka/hiccup_d3/macros.clj
+++ b/src/main/tech/thomas_sojka/hiccup_d3/macros.clj
@@ -1,0 +1,7 @@
+(ns tech.thomas-sojka.hiccup-d3.macros)
+
+(defmacro build-chart [{:keys [title data code]}]
+  `{:title ~title
+    :data  ~data
+    :chart ~code
+    :code  '~(last code)})


### PR DESCRIPTION
The CLJS code segments that generate the D3js charts in `app.cljs` are currently duplicated for every chart: 
(1) as `:code` key, where it is escaped for the client to see the raw version
(2) as `:chart` key, where it is actually rendered
By constructing the whole chart data structure via a macro this duplication can be avoided. 